### PR TITLE
fix (salesforce): prioritise pull config selected fields

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -519,6 +519,7 @@ def main_impl():
             default_start_date=CONFIG.get("start_date"),
             api_type=CONFIG.get("api_type"),
             limit_tasks_month=CONFIG.get("limit_tasks_month"),
+            pull_config_objects=CONFIG.get("OBJECTS"),
         )
         sf.login()
 


### PR DESCRIPTION
https://app.asana.com/1/12635457239181/project/1204908890891502/task/1211160326553468?focus=true
https://app.asana.com/1/12635457239181/project/1204908890891502/task/1211196959354646?focus=true

Prioritises fields in pull config for Salesforce extracts, where the tenant has >500 columns in a given SFDC model.

Tested by running Accounts for 5966 locally to the point of query building and verifying that all available pull config columns are in the query. 